### PR TITLE
feat(nyc): better support for sourcemaps

### DIFF
--- a/src/config/nyc-test.js
+++ b/src/config/nyc-test.js
@@ -22,7 +22,7 @@ suite('nyc scaffolder', () => {
     assert.deepEqual(
       await scaffoldNyc({projectRoot, vcs: {owner: vcsOwner, name: vcsName, host: 'GitHub'}, visibility: 'Public'}),
       {
-        devDependencies: ['nyc'],
+        devDependencies: ['nyc', '@istanbuljs/nyc-config-babel', 'babel-plugin-istanbul'],
         vcsIgnore: {files: [], directories: ['/coverage/', '/.nyc_output/']},
         badges: {
           status: {
@@ -39,6 +39,7 @@ suite('nyc scaffolder', () => {
       fsPromises.writeFile,
       `${projectRoot}/.nycrc`,
       JSON.stringify({
+        extends: '@istanbuljs/nyc-config-babel',
         reporter: ['lcov', 'text-summary', 'html'],
         exclude: ['src/**/*-test.js', 'test/', 'thirdparty-wrappers/', 'vendor/']
       })

--- a/src/config/nyc.js
+++ b/src/config/nyc.js
@@ -4,13 +4,14 @@ export default async function ({projectRoot, vcs, visibility}) {
   await promises.writeFile(
     `${projectRoot}/.nycrc`,
     JSON.stringify({
+      extends: '@istanbuljs/nyc-config-babel',
       reporter: ['lcov', 'text-summary', 'html'],
       exclude: ['src/**/*-test.js', 'test/', 'thirdparty-wrappers/', 'vendor/']
     })
   );
 
   return {
-    devDependencies: ['nyc'],
+    devDependencies: ['nyc', '@istanbuljs/nyc-config-babel', 'babel-plugin-istanbul'],
     vcsIgnore: {files: [], directories: ['/coverage/', '/.nyc_output/']},
     badges: {
       status: {


### PR DESCRIPTION
- Right now when apps run tests with nyc, the line numbers for errors in test output are the babelified line numbers from using @babel/register as setup in the . This makes it hard to debug what line really caused a problem when they come up.
- the key is adding [nyc-config-babel](https://www.npmjs.com/package/@istanbuljs/nyc-config-babel) to the .nycrc file
- i'm not sure how to handle the fact that this pins the configuration of nyc with babel. The recommendation from [@istanbul/nyc-config-babel](https://www.npmjs.com/package/@istanbuljs/nyc-config-babel) is to also add this as a babel plugin when used. I have not found any problems with not including this as a babel plugin, but feel like there's a piece I'm overlooking. The babel-plugin-instanbul package recommends [turning off source maps in the nyc config](https://www.npmjs.com/package/babel-plugin-istanbul#mocha-on-nodejs-through-nyc) if you already have mocha instrumented to babelify the code. I'd like to better understand this, but this is a start that does actually get rid of the original problem.